### PR TITLE
Upgrade BlazingCache to 1.9.0, with StoreByReference

### DIFF
--- a/blazingcache-V1-test/pom.xml
+++ b/blazingcache-V1-test/pom.xml
@@ -30,10 +30,10 @@
     <!-- Implementation coordinates -->
     <implementation-groupId>org.blazingcache</implementation-groupId>
     <implementation-artifactId>blazingcache-jcache</implementation-artifactId>
-    <implementation-version>1.4.0</implementation-version>
+    <implementation-version>1.9.0</implementation-version>
 
     <!-- CacheManager and Cache implementation. Used by the unwrap tests. -->
-    <CacheManagerImpl>blazingcache.jcache.BlazingCacheCacheManager</CacheManagerImpl>
+    <CacheManagerImpl>blazingcache.jcache.BlazingCacheManager</CacheManagerImpl>
     <CacheImpl>blazingcache.jcache.BlazingCacheCache</CacheImpl>
     <CacheEntryImpl>blazingcache.jcache.BlazingCacheEntry</CacheEntryImpl>
 


### PR DESCRIPTION
And fixing a typo on CacheManagerImpl=blazingcache.jcache.BlazingCacheManager
